### PR TITLE
Feature/enhance testing assertions

### DIFF
--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -175,4 +175,21 @@ class BotManTester
     {
         return $this->driver->getBotMessages();
     }
+
+    /**
+     * @test
+     * @param array $payload
+     * @return $this
+     */
+    public function assertPayload(array $payload)
+    {
+        $this->listen();
+        $messages = $this->getMessages();
+
+        /** @var Question $question */
+        $message = array_first($messages);
+        PHPUnit::assertEquals($message->toArray(), $payload);
+
+        return $this;
+    }
 }

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -88,16 +88,20 @@ class BotManTester
 
     /**
      * @param $text
+     * @return $this
      */
     public function assertReply($text)
     {
         PHPUnit::assertSame($this->getReply()->getText(), $text);
+
+        return $this;
     }
 
     /**
      * Assert that there are specific multiple replies.
      *
      * @param array $expectedMessages
+     * @return $this
      */
     public function assertReplies($expectedMessages)
     {
@@ -107,30 +111,41 @@ class BotManTester
         foreach ($actualMessages as $key => $actualMessage) {
             PHPUnit::assertSame($expectedMessages[$key], $actualMessage->getText());
         }
+
+        return $this;
     }
 
     /**
      * @param $text
+     * @return $this
      */
     public function assertReplyIsNot($text)
     {
         PHPUnit::assertNotSame($this->getReply()->getText(), $text);
+
+        return $this;
     }
 
     /**
      * @param array $haystack
+     * @return $this
      */
     public function assertReplyIn(array $haystack)
     {
         PHPUnit::assertTrue(in_array($this->getReply()->getText(), $haystack));
+
+        return $this;
     }
 
     /**
      * @param array $haystack
+     * @return $this
      */
     public function assertReplyNotIn(array $haystack)
     {
         PHPUnit::assertFalse(in_array($this->getReply()->getText(), $haystack));
+
+        return $this;
     }
 
     /**

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -200,7 +200,6 @@ class BotManTester
     }
 
     /**
-     * @test
      * @param array $payload
      * @return $this
      */

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -74,7 +74,6 @@ class BotManTester
         $this->driver->resetBotMessages();
         $this->listen();
 
-
         return $this;
     }
 
@@ -95,7 +94,7 @@ class BotManTester
      */
     public function assertReply($message)
     {
-        if($this->getReply() instanceof OutgoingMessage) {
+        if ($this->getReply() instanceof OutgoingMessage) {
             PHPUnit::assertSame($this->getReply()->getText(), $message);
         } else {
             PHPUnit::assertEquals($message, $this->getReply());
@@ -115,7 +114,7 @@ class BotManTester
         $actualMessages = $this->getMessages();
 
         foreach ($actualMessages as $key => $actualMessage) {
-            if($actualMessage instanceof OutgoingMessage) {
+            if ($actualMessage instanceof OutgoingMessage) {
                 PHPUnit::assertSame($expectedMessages[$key], $actualMessage->getText());
             } else {
                 PHPUnit::assertEquals($expectedMessages[$key], $actualMessage);
@@ -212,6 +211,7 @@ class BotManTester
         /** @var Question $question */
         $message = array_pop($messages);
         PHPUnit::assertEquals($message->toArray(), $payload);
+
         return $this;
     }
 }


### PR DESCRIPTION
This PR intends to enhance the current testing suite provide more testing features.

I deleted the msg before, because I changed a lot today.

**1. Chaining**

Before it was not possible to to test more than one reply. Assertions now returns the object to make that possible like:

```php
$this->bot
            ->receives('test')
            ->assertReply('hello!')
            ->receives('test')
            ->assertReply('hello!');
```

**2. Usage of listen()**

I had with some new features problems because of the listen() method. (too less or too much msg given) I now placed this method only in the `receives` method. Because this is the only place where we want to check for new messages. I also reset the messages there.

**3. assertReply() and assertReplies() changes**

Before you could test multiple replies like this:

```php
// test
   ->assertReplies([
                'Nice :-)',
                'Next question:',
                'Which color is your car?'
            ])
```

This also worked for BotMan question objects. So "Which color is your car?" could be the text of this question. But if one of these replies was another msg type like FB Template it does not work. I change `assertReply` and `assertReplies` to make it work like that:
```php
$tuningTemplate = ButtonTemplate::create('Please select from here:')
            ->addButtons([
                ElementButton::create('A')->type('payload')->payload('a'),
                ElementButton::create('B')->type('payload')->payload('b'),
                ElementButton::create('C')->type('payload')->payload('c'),
            ]);

$this->bot->receives('start car conversation')
    ->assertReplies([
        'Ok lets go!',
        $tuningTemplate
]);
```
or

```php
 $question = Question::create("Huh - you woke me up. What do you need?")
            ->fallback('Unable to ask question')
            ->callbackId('ask_reason')
            ->addButtons([
                Button::create('Tell a joke')->value('joke'),
                Button::create('Give me a fancy quote')->value('quote'),
            ]);

$this->bot
    ->receives('Start Conversation')
    ->assertReply($question)
```

**4. Still useful?**

Not sure if we still need `assertQuestion()`. It only checks the last of the incoming messages and does not check the buttons of the question.

**5. Summary**

Overall I think this is good start for the testing suite and provides much more testing features. But still much to do. Please let me know what you think about that.