### PR TITLE
Fix method to work for template name and data

### DIFF
--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -333,13 +333,14 @@ class BotManTester
      * @param bool $strict
      * @return $this
      */
-    public function assertTemplate(string $template, $strict = false)
+    public function assertTemplate($template, $strict = false)
     {
         $message = $this->getReply();
-        PHPUnit::assertInstanceOf($template, $message);
 
         if ($strict) {
-            PHPUnit::assertSame($template, $message);
+            PHPUnit::assertEquals($template, $message);
+        } else {
+            PHPUnit::assertInstanceOf($template, $message);
         }
 
         return $this;


### PR DESCRIPTION
This PR fixes the `assertTemplate` method where the last change added a bug. It was not possible anymore to check for the whole template object. Only the name assertion was working.