### PR TITLE
New methods for question and template testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=7.0",
         "botman/botman": "~2.0",
+        "botman/driver-facebook": "^1.0",
         "guzzlehttp/guzzle": "~6.0",
         "illuminate/support": "~5.5.0",
         "illuminate/contracts": "~5.5.0",

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -96,7 +96,7 @@ class BotManTester
      * @param IncomingMessage $message
      * @return $this
      */
-    public function receivesIncomingMessage($message)
+    public function receivesRaw($message)
     {
         $this->driver->messages = [$message];
 
@@ -114,7 +114,7 @@ class BotManTester
      */
     public function receives($message)
     {
-        return $this->receivesIncomingMessage(new IncomingMessage($message, $this->user_id, $this->channel));
+        return $this->receivesRaw(new IncomingMessage($message, $this->user_id, $this->channel));
     }
 
     /**
@@ -138,7 +138,7 @@ class BotManTester
         $message = new IncomingMessage(Location::PATTERN, $this->user_id, $this->channel);
         $message->setLocation(new Location($latitude, $longitude, null));
 
-        return $this->receivesIncomingMessage($message);
+        return $this->receivesRaw($message);
     }
 
     /**
@@ -157,7 +157,7 @@ class BotManTester
         $message = new IncomingMessage(Image::PATTERN, $this->user_id, $this->channel);
         $message->setImages($images);
 
-        return $this->receivesIncomingMessage($message);
+        return $this->receivesRaw($message);
     }
 
     /**
@@ -177,7 +177,7 @@ class BotManTester
         $message = new IncomingMessage(Audio::PATTERN, $this->user_id, $this->channel);
         $message->setAudio($audio);
 
-        return $this->receivesIncomingMessage($message);
+        return $this->receivesRaw($message);
     }
 
     /**
@@ -196,7 +196,7 @@ class BotManTester
         $message = new IncomingMessage(Video::PATTERN, $this->user_id, $this->channel);
         $message->setVideos($videos);
 
-        return $this->receivesIncomingMessage($message);
+        return $this->receivesRaw($message);
     }
 
     /**
@@ -215,7 +215,7 @@ class BotManTester
         $message = new IncomingMessage(File::PATTERN, $this->user_id, $this->channel);
         $message->setFiles($files);
 
-        return $this->receivesIncomingMessage($message);
+        return $this->receivesRaw($message);
     }
 
     /**
@@ -228,7 +228,7 @@ class BotManTester
         $this->driver->setEventName($name);
         $this->driver->setEventPayload($payload);
 
-        return $this->receivesIncomingMessage(new IncomingMessage('', $this->user_id, $this->channel));
+        return $this->receivesRaw(new IncomingMessage('', $this->user_id, $this->channel));
     }
 
     /**
@@ -357,7 +357,7 @@ class BotManTester
      * @param OutgoingMessage $message
      * @return $this
      */
-    public function assertOutgoingMessage($message)
+    public function assertRaw($message)
     {
         PHPUnit::assertSame($message, $this->getReply());
 
@@ -368,7 +368,7 @@ class BotManTester
      * @param int $times
      * @return $this
      */
-    public function skipReply($times = 1)
+    public function reply($times = 1)
     {
         foreach (range(1, $times) as $time) {
             $this->getReply();

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -275,7 +275,7 @@ class BotManTester
     public function assertReplyIsNot($text)
     {
         $message = $this->getReply();
-        if($message instanceof OutgoingMessage){
+        if ($message instanceof OutgoingMessage) {
             PHPUnit::assertNotSame($message->getText(), $text);
         } else {
             PHPUnit::assertNotEquals($message, $text);

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -322,7 +322,7 @@ class BotManTester
      * @param null $text
      * @return $this
      */
-    public function assertQuestion($text = null)
+    public function assertQuestion($text = null, $closure = null)
     {
         /** @var Question $question */
         $question = $this->getReply();
@@ -330,6 +330,10 @@ class BotManTester
 
         if (! is_null($text)) {
             PHPUnit::assertSame($text, $question->getText());
+        }
+
+        if (is_callable($closure)){
+            call_user_func($closure, new QuestionTester($question));
         }
 
         return $this;

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -332,7 +332,7 @@ class BotManTester
             PHPUnit::assertSame($text, $question->getText());
         }
 
-        if (is_callable($closure)){
+        if (! is_null($closure)) {
             call_user_func($closure, new QuestionTester($question));
         }
 

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -96,7 +96,7 @@ class BotManTester
      * @param IncomingMessage $message
      * @return $this
      */
-    public function receivesRaw($message)
+    public function receivesIncomingMessage($message)
     {
         $this->driver->messages = [$message];
 
@@ -114,7 +114,7 @@ class BotManTester
      */
     public function receives($message)
     {
-        return $this->receivesRaw(new IncomingMessage($message, $this->user_id, $this->channel));
+        return $this->receivesIncomingMessage(new IncomingMessage($message, $this->user_id, $this->channel));
     }
 
     /**
@@ -138,7 +138,7 @@ class BotManTester
         $message = new IncomingMessage(Location::PATTERN, $this->user_id, $this->channel);
         $message->setLocation(new Location($latitude, $longitude, null));
 
-        return $this->receivesRaw($message);
+        return $this->receivesIncomingMessage($message);
     }
 
     /**
@@ -157,7 +157,7 @@ class BotManTester
         $message = new IncomingMessage(Image::PATTERN, $this->user_id, $this->channel);
         $message->setImages($images);
 
-        return $this->receivesRaw($message);
+        return $this->receivesIncomingMessage($message);
     }
 
     /**
@@ -177,7 +177,7 @@ class BotManTester
         $message = new IncomingMessage(Audio::PATTERN, $this->user_id, $this->channel);
         $message->setAudio($audio);
 
-        return $this->receivesRaw($message);
+        return $this->receivesIncomingMessage($message);
     }
 
     /**
@@ -196,7 +196,7 @@ class BotManTester
         $message = new IncomingMessage(Video::PATTERN, $this->user_id, $this->channel);
         $message->setVideos($videos);
 
-        return $this->receivesRaw($message);
+        return $this->receivesIncomingMessage($message);
     }
 
     /**
@@ -215,7 +215,7 @@ class BotManTester
         $message = new IncomingMessage(File::PATTERN, $this->user_id, $this->channel);
         $message->setFiles($files);
 
-        return $this->receivesRaw($message);
+        return $this->receivesIncomingMessage($message);
     }
 
     /**
@@ -228,7 +228,7 @@ class BotManTester
         $this->driver->setEventName($name);
         $this->driver->setEventPayload($payload);
 
-        return $this->receivesRaw(new IncomingMessage('', $this->user_id, $this->channel));
+        return $this->receivesIncomingMessage(new IncomingMessage('', $this->user_id, $this->channel));
     }
 
     /**
@@ -350,7 +350,7 @@ class BotManTester
      * @param OutgoingMessage $message
      * @return $this
      */
-    public function assertRaw($message)
+    public function assertOutgoingMessage($message)
     {
         PHPUnit::assertSame($message, $this->getReply());
 
@@ -361,7 +361,7 @@ class BotManTester
      * @param int $times
      * @return $this
      */
-    public function reply($times = 1)
+    public function skipReply($times = 1)
     {
         foreach (range(1, $times) as $time) {
             $this->getReply();

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -274,7 +274,14 @@ class BotManTester
      */
     public function assertReplyIsNot($text)
     {
-        PHPUnit::assertNotSame($this->getReply()->getText(), $text);
+        $message = $this->getReply();
+        if($message instanceof OutgoingMessage){
+            PHPUnit::assertNotSame($message->getText(), $text);
+        } else {
+            PHPUnit::assertNotEquals($message, $text);
+        }
+
+        array_unshift($this->botMessages, $message);
 
         return $this;
     }

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -344,14 +344,14 @@ class BotManTester
      * @param bool $strict
      * @return $this
      */
-    public function assertTemplate($template, $strict = false)
+    public function assertTemplate($template, $closure = null)
     {
         $message = $this->getReply();
 
-        if ($strict) {
-            PHPUnit::assertEquals($template, $message);
-        } else {
-            PHPUnit::assertInstanceOf($template, $message);
+        PHPUnit::assertInstanceOf($template, $message);
+
+        if(is_callable($closure)) {
+            call_user_func($closure, new TemplateTester($message));
         }
 
         return $this;

--- a/src/Testing/ButtonTester.php
+++ b/src/Testing/ButtonTester.php
@@ -20,50 +20,70 @@ class ButtonTester
     public function assertText($text)
     {
         PHPUnit::assertSame($text, $this->button['text']);
+
+        return $this;
     }
 
     public function assertTextIsNot($text)
     {
         PHPUnit::assertNotSame($text, $this->button['text']);
+
+        return $this;
     }
 
     public function assertName($name)
     {
         PHPUnit::assertSame($name, $this->button['name']);
+
+        return $this;
     }
 
     public function assertNameIsNot($name)
     {
         PHPUnit::assertNotSame($name, $this->button['name']);
+
+        return $this;
     }
 
     public function assertValue($value)
     {
         PHPUnit::assertSame($value, $this->button['value']);
+
+        return $this;
     }
 
     public function assertValueIsNot($value)
     {
         PHPUnit::assertNotSame($value, $this->button['value']);
+
+        return $this;
     }
 
     public function assertImage($image_url)
     {
         PHPUnit::assertSame($image_url, $this->button['image_url']);
+
+        return $this;
     }
 
     public function assertImageIsNot($image_url)
     {
         PHPUnit::assertNotSame($image_url, $this->button['image_url']);
+
+        return $this;
     }
 
     public function assertAdditional($additional)
     {
         PHPUnit::assertEqual($additional, $this->button['additional']);
+
+        return $this;
     }
 
     public function assertAdditionalIsNot($additional)
     {
         PHPUnit::assertNotEqual($additional, $this->button['additional']);
+
+        return $this;
     }
 }

--- a/src/Testing/ButtonTester.php
+++ b/src/Testing/ButtonTester.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace BotMan\Studio\Testing;
+
+use BotMan\BotMan\Messages\Outgoing\Question;
+use BotMan\Drivers\Facebook\Extensions\Element;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * Class QuestionTester.
+ */
+class ButtonTester
+{
+
+    protected $button;
+
+    public function __construct(array $button)
+    {
+        $this->button = $button;
+    }
+
+    public function assertText($text)
+    {
+        PHPUnit::assertSame($text, $this->button['text']);
+    }
+
+    public function assertTextIsNot($text)
+    {
+        PHPUnit::assertNotSame($text, $this->button['text']);
+    }
+
+    public function assertName($name)
+    {
+        PHPUnit::assertSame($name, $this->button['name']);
+    }
+
+    public function assertNameIsNot($name)
+    {
+        PHPUnit::assertNotSame($name, $this->button['name']);
+    }
+
+    public function assertValue($value)
+    {
+        PHPUnit::assertSame($value, $this->button['value']);
+    }
+
+    public function assertValueIsNot($value)
+    {
+        PHPUnit::assertNotSame($value, $this->button['value']);
+    }
+
+    public function assertImage($image_url)
+    {
+        PHPUnit::assertSame($image_url, $this->button['image_url']);
+    }
+
+    public function assertImageIsNot($image_url)
+    {
+        PHPUnit::assertNotSame($image_url, $this->button['image_url']);
+    }
+
+    public function assertAdditional($additional)
+    {
+        PHPUnit::assertEqual($additional, $this->button['additional']);
+    }
+
+    public function assertAdditionalIsNot($additional)
+    {
+        PHPUnit::assertNotEqual($additional, $this->button['additional']);
+    }
+}

--- a/src/Testing/ElementButtonTester.php
+++ b/src/Testing/ElementButtonTester.php
@@ -7,74 +7,103 @@ use BotMan\Drivers\Facebook\Extensions\Element;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
- * Class QuestionTester.
+ * Class ElementButtonTester.
  */
 class ElementButtonTester
 {
 
-    protected $element;
+    protected $button;
 
-    protected $match = true;
-
-    public function __construct(array $element)
+    public function __construct(array $button)
     {
-        $this->element = $element;
-    }
-
-    public function assertButtonCount($count)
-    {
-        $this->setMatch($count == count($this->element['buttons']));
+        $this->button = $button;
 
         return $this;
     }
 
-    public function assertHasButton(array $data) {
-        $button_matches = false;
+    public function assertTitle($title)
+    {
+        PHPUnit::assertSame($title, $this->button['title']);
 
-        foreach ($this->element['buttons'] as $button) {
-            if($button_matches=$this->checkButton($button, $data)) {
-                break;
-            }
-
-        }
-        $this->setMatch($button_matches);
+        return $this;
     }
 
-    public function assertHasNotButton(array $data) {
-        $button_matches = false;
+    public function assertTitleIsNot($title)
+    {
+        PHPUnit::assertNotSame($title, $this->button['title']);
 
-        foreach ($this->element['buttons'] as $button) {
-            if($button_matches=$this->checkButton($button, $data)) {
-                break;
-            }
-
-        }
-        $this->setMatch(!$button_matches);
+        return $this;
     }
 
-    public function setMatch(bool $match) {
-        if(!$match) {
-            $this->match = $match;
-        }
+    public function assertType($type)
+    {
+        PHPUnit::assertSame($type, $this->button['type']);
+
+        return $this;
     }
 
-    public function getMatch() {
-        return $this->match;
+    public function assertTypeIsNot($type)
+    {
+        PHPUnit::assertNotSame($type, $this->button['type']);
+
+        return $this;
     }
 
-    private function checkButton($button, $data) {
-        $attributes_matches = true;
+    public function assertUrl($url)
+    {
+        PHPUnit::assertSame($url, $this->button['url']);
 
-        foreach ($data as $key => $value) {
+        return $this;
+    }
 
-            if(array_has($button, $key) && array_get($button, $key) == $value) {
-                continue;
-            }
+    public function assertUrlIsNot($url)
+    {
+        PHPUnit::assertNotSame($url, $this->button['url']);
 
-            $attributes_matches = false;
-            break;
-        }
+        return $this;
+    }
 
-        return ($attributes_matches) ? true : false;
+    public function assertPayload($payload)
+    {
+        PHPUnit::assertSame($payload, $this->button['payload']);
+
+        return $this;
+    }
+
+    public function assertPayloadIsNot($payload)
+    {
+        PHPUnit::assertNotSame($payload, $this->button['payload']);
+
+        return $this;
+    }
+
+
+    public function assertHeightRatio($webview_height_ratio)
+    {
+        PHPUnit::assertSame($webview_height_ratio, $this->button['webview_height_ratio']);
+
+        return $this;
+    }
+
+    public function assertMessengerExtension($messenger_extensions = true)
+    {
+        PHPUnit::assertSame($messenger_extensions, $this->button['messenger_extensions']);
+
+        return $this;
+    }
+
+    public function assertFallbackUrl($fallback_url)
+    {
+        PHPUnit::assertSame($fallback_url, $this->button['fallback_url']);
+
+        return $this;
+    }
+
+    public function assertShareContents($closure)
+    {
+        $share_content = $this->button['share_contents'];
+        call_user_func($closure, new TemplateTester($share_content));
+
+        return $this;
     }
 }

--- a/src/Testing/ElementButtonTester.php
+++ b/src/Testing/ElementButtonTester.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace BotMan\Studio\Testing;
+
+use BotMan\BotMan\Messages\Outgoing\Question;
+use BotMan\Drivers\Facebook\Extensions\Element;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * Class QuestionTester.
+ */
+class ElementButtonTester
+{
+
+    protected $element;
+
+    protected $match = true;
+
+    public function __construct(array $element)
+    {
+        $this->element = $element;
+    }
+
+    public function assertButtonCount($count)
+    {
+        $this->setMatch($count == count($this->element['buttons']));
+
+        return $this;
+    }
+
+    public function assertHasButton(array $data) {
+        $button_matches = false;
+
+        foreach ($this->element['buttons'] as $button) {
+            if($button_matches=$this->checkButton($button, $data)) {
+                break;
+            }
+
+        }
+        $this->setMatch($button_matches);
+    }
+
+    public function assertHasNotButton(array $data) {
+        $button_matches = false;
+
+        foreach ($this->element['buttons'] as $button) {
+            if($button_matches=$this->checkButton($button, $data)) {
+                break;
+            }
+
+        }
+        $this->setMatch(!$button_matches);
+    }
+
+    public function setMatch(bool $match) {
+        if(!$match) {
+            $this->match = $match;
+        }
+    }
+
+    public function getMatch() {
+        return $this->match;
+    }
+
+    private function checkButton($button, $data) {
+        $attributes_matches = true;
+
+        foreach ($data as $key => $value) {
+
+            if(array_has($button, $key) && array_get($button, $key) == $value) {
+                continue;
+            }
+
+            $attributes_matches = false;
+            break;
+        }
+
+        return ($attributes_matches) ? true : false;
+    }
+}

--- a/src/Testing/ElementTester.php
+++ b/src/Testing/ElementTester.php
@@ -7,65 +7,77 @@ use BotMan\Drivers\Facebook\Extensions\Element;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**
- * Class QuestionTester.
+ * Class ElementTester
  */
-class ButtonTester
+class ElementTester
 {
 
-    protected $button;
+    protected $element;
 
-    public function __construct(array $button)
+    public function __construct(array $element)
     {
-        $this->button = $button;
+        $this->element = $element;
     }
 
-    public function assertText($text)
+    public function assertTitle($title)
     {
-        PHPUnit::assertSame($text, $this->button['text']);
+        PHPUnit::assertSame($title, $this->element['title']);
+
+        return $this;
     }
 
-    public function assertTextIsNot($text)
+    public function assertTitleIsNot($title)
     {
-        PHPUnit::assertNotSame($text, $this->button['text']);
+        PHPUnit::assertNotSame($title, $this->element['title']);
+
+        return $this;
     }
 
-    public function assertName($name)
+    public function assertSubtitle($subtitle)
     {
-        PHPUnit::assertSame($name, $this->button['name']);
+        PHPUnit::assertSame($subtitle, $this->element['subtitle']);
+
+        return $this;
     }
 
-    public function assertNameIsNot($name)
+    public function assertSubtitleIsNot($subtitle)
     {
-        PHPUnit::assertNotSame($name, $this->button['name']);
-    }
+        PHPUnit::assertNotSame($subtitle, $this->element['subtitle']);
 
-    public function assertValue($value)
-    {
-        PHPUnit::assertSame($value, $this->button['value']);
-    }
-
-    public function assertValueIsNot($value)
-    {
-        PHPUnit::assertNotSame($value, $this->button['value']);
+        return $this;
     }
 
     public function assertImage($image_url)
     {
-        PHPUnit::assertSame($image_url, $this->button['image_url']);
+        PHPUnit::assertSame($image_url, $this->element['image_url']);
+
+        return $this;
     }
 
     public function assertImageIsNot($image_url)
     {
-        PHPUnit::assertNotSame($image_url, $this->button['image_url']);
+        PHPUnit::assertNotSame($image_url, $this->element['image_url']);
+
+        return $this;
     }
 
-    public function assertAdditional($additional)
+    public function assertButton($index, $closure)
     {
-        PHPUnit::assertEqual($additional, $this->button['additional']);
+        $button = $this->element['buttons'][$index];
+        call_user_func($closure, new ElementButtonTester($button));
+
+        return $this;
     }
 
-    public function assertAdditionalIsNot($additional)
+    public function assertFirstButton($closure)
     {
-        PHPUnit::assertNotEqual($additional, $this->button['additional']);
+        return $this->assertButton(0, $closure);
+    }
+
+    public function assertLastButton($closure)
+    {
+        $last_index = count($this->element['buttons']) - 1;
+
+        return $this->assertButton($last_index, $closure);
     }
 }

--- a/src/Testing/ElementTester.php
+++ b/src/Testing/ElementTester.php
@@ -2,6 +2,8 @@
 
 namespace BotMan\Studio\Testing;
 
+use BotMan\BotMan\Messages\Outgoing\Question;
+use BotMan\Drivers\Facebook\Extensions\Element;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 /**

--- a/src/Testing/QuestionTester.php
+++ b/src/Testing/QuestionTester.php
@@ -58,38 +58,4 @@ class QuestionTester
         $button = $this->question['actions'][$index];
         call_user_func($closure, new ButtonTester($button));
     }
-
-    public function assertHasButton($text)
-    {
-        PHPUnit::assertTrue(in_array($text, $this->pluck('text')));
-    }
-
-    public function assertHasNotButton($text)
-    {
-        PHPUnit::assertFalse(in_array($text, $this->pluck('text')));
-    }
-
-    public function assertHasValue($value)
-    {
-        PHPUnit::assertTrue(in_array($value, $this->pluck('value')));
-    }
-
-    public function assertHasNotValue($value)
-    {
-        PHPUnit::assertFalse(in_array($value, $this->pluck('value')));
-    }
-
-    public function assertButtons(array $buttons)
-    {
-        sort($buttons);
-
-        PHPUnit::assertEquals(array_sort($this->pluck('text')), $buttons);
-    }
-
-
-    private function pluck ($type) {
-        return collect($this->question['actions'])
-            ->pluck($type)
-            ->toArray();
-    }
 }

--- a/src/Testing/QuestionTester.php
+++ b/src/Testing/QuestionTester.php
@@ -21,41 +21,57 @@ class QuestionTester
     public function assertText($text)
     {
         PHPUnit::assertSame($text, $this->question['text']);
+
+        return $this;
     }
 
     public function assertTextIsNot($text)
     {
         PHPUnit::assertNotSame($text, $this->question['text']);
+
+        return $this;
     }
 
     public function assertFallback($fallback)
     {
         PHPUnit::assertSame($fallback, $this->question['fallback']);
+
+        return $this;
     }
 
     public function assertFallbackIsNot($fallback)
     {
         PHPUnit::assertNotSame($fallback, $this->question['fallback']);
+
+        return $this;
     }
 
     public function assertCallbackId($callback)
     {
         PHPUnit::assertSame($callback, $this->question['callback_id']);
+
+        return $this;
     }
 
     public function assertCallbackIdIsNot($callback)
     {
         PHPUnit::assertNotSame($callback, $this->question['callback_id']);
+
+        return $this;
     }
 
     public function assertButtonCount($count)
     {
         PHPUnit::assertCount($count, $this->question['actions']);
+
+        return $this;
     }
 
     public function assertButton($index, $closure)
     {
         $button = $this->question['actions'][$index];
         call_user_func($closure, new ButtonTester($button));
+
+        return $this;
     }
 }

--- a/src/Testing/QuestionTester.php
+++ b/src/Testing/QuestionTester.php
@@ -74,4 +74,16 @@ class QuestionTester
 
         return $this;
     }
+
+    public function assertFirstButton($closure)
+    {
+        return $this->assertButton(0, $closure);
+    }
+
+    public function assertLastButton($closure)
+    {
+        $last_index = count($this->question['actions']) - 1;
+
+        return $this->assertButton($last_index, $closure);
+    }
 }

--- a/src/Testing/QuestionTester.php
+++ b/src/Testing/QuestionTester.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BotMan\Studio\Testing;
+
+use BotMan\BotMan\Messages\Outgoing\Question;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * Class QuestionTester.
+ */
+class QuestionTester
+{
+
+    protected $question;
+
+    public function __construct(Question $question)
+    {
+        $this->question = $question->toArray();
+    }
+
+    public function assertText($text)
+    {
+        PHPUnit::assertSame($text, $this->question['text']);
+    }
+
+    public function assertTextIsNot($text)
+    {
+        PHPUnit::assertNotSame($text, $this->question['text']);
+    }
+
+    public function assertFallback($fallback)
+    {
+        PHPUnit::assertSame($fallback, $this->question['fallback']);
+    }
+
+    public function assertFallbackIsNot($fallback)
+    {
+        PHPUnit::assertNotSame($fallback, $this->question['fallback']);
+    }
+
+    public function assertCallbackId($callback)
+    {
+        PHPUnit::assertSame($callback, $this->question['callback_id']);
+    }
+
+    public function assertCallbackIdIsNot($callback)
+    {
+        PHPUnit::assertNotSame($callback, $this->question['callback_id']);
+    }
+
+    public function assertButtonCount($count)
+    {
+        PHPUnit::assertCount($count, $this->question['actions']);
+    }
+
+    public function assertButton($index, $closure)
+    {
+        $button = $this->question['actions'][$index];
+        call_user_func($closure, new ButtonTester($button));
+    }
+
+    public function assertHasButton($text)
+    {
+        PHPUnit::assertTrue(in_array($text, $this->pluck('text')));
+    }
+
+    public function assertHasNotButton($text)
+    {
+        PHPUnit::assertFalse(in_array($text, $this->pluck('text')));
+    }
+
+    public function assertHasValue($value)
+    {
+        PHPUnit::assertTrue(in_array($value, $this->pluck('value')));
+    }
+
+    public function assertHasNotValue($value)
+    {
+        PHPUnit::assertFalse(in_array($value, $this->pluck('value')));
+    }
+
+    public function assertButtons(array $buttons)
+    {
+        sort($buttons);
+
+        PHPUnit::assertEquals(array_sort($this->pluck('text')), $buttons);
+    }
+
+
+    private function pluck ($type) {
+        return collect($this->question['actions'])
+            ->pluck($type)
+            ->toArray();
+    }
+}

--- a/src/Testing/TemplateTester.php
+++ b/src/Testing/TemplateTester.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace BotMan\Studio\Testing;
+
+use BotMan\BotMan\Messages\Outgoing\Question;
+use function GuzzleHttp\default_ca_bundle;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * Class QuestionTester.
+ */
+class TemplateTester
+{
+
+    protected $template;
+
+    public function __construct($template)
+    {
+        $this->template = $template->toArray()['attachment'];
+    }
+
+    public function assertElementCount($count)
+    {
+        PHPUnit::assertCount($count, $this->template['payload']['elements']);
+
+        return $this;
+    }
+
+    public function assertElement($index, $closure)
+    {
+
+    }
+
+    public function assertHasElement(array $data, $closure = null) {
+        $element_matches = false;
+
+        foreach ($this->template['payload']['elements'] as $element) {
+            if($element_matches = $this->checkElement($element, $data, $closure)){
+                break;
+            }
+        }
+
+        PHPUnit::assertTrue($element_matches, 'Failed asserting that template has given element');
+
+        return $this;
+    }
+
+    public function assertHasNotElement(array $data, $closure = null) {
+        $element_matches = false;
+
+        foreach ($this->template['payload']['elements'] as $element) {
+            if($element_matches = $this->checkElement($element, $data, $closure)){
+                break;
+            }
+        }
+
+        PHPUnit::assertFalse($element_matches, 'Failed asserting that template does not have given element');
+
+        return $this;
+    }
+
+//    public function assertElement($index, array $data, $closure = null){
+//        $element = $this->template['payload']['elements'][$index];
+//        $element_matches = $this->checkElement($element, $data, $closure);
+//
+//        PHPUnit::assertTrue($element_matches, "Failed asserting that templates element with index {$index}");
+//
+//        return $this;
+//    }
+
+    public function __call($name, $arguments)
+    {
+        $kebab_name = kebab_case($name);
+
+        if(starts_with($kebab_name, 'assert') && ends_with($kebab_name, 'element')){
+            switch(explode('-', $kebab_name)[1]) {
+                case 'first':
+                    $index = 0;
+                    break;
+                case 'second':
+                    $index = 1;
+                    break;
+                case 'third':
+                    $index = 2;
+                    break;
+                case 'forth':
+                    $index = 3;
+                    break;
+                case 'fifth':
+                    $index = 4;
+                    break;
+                case 'sixth':
+                    $index = 5;
+                    break;
+                case 'seventh':
+                    $index = 6;
+                    break;
+                case 'eighth':
+                    $index = 7;
+                    break;
+                case 'ninth':
+                    $index = 8;
+                    break;
+                case 'last':
+                    $index = count($this->template['payload']['elements']) - 1;
+                    break;
+                default:
+                    $index = null;
+            }
+            if($index) {
+                return call_user_func([$this, 'assertElement'], $index, $arguments[0], $arguments[1] ?? null);
+            }
+        }
+
+        throw new \Exception("There is no method {$name}");
+    }
+
+    private function checkElement($actual, $data, $closure) {
+        $attributes_matches = true;
+
+        foreach ($data as $key => $value) {
+            if(array_has($actual, $key) && array_get($actual, $key) == $value) {
+                continue;
+            }
+            $attributes_matches = false;
+            break;
+        }
+
+        $buttons_matches = true;
+
+        if (is_callable($closure)) {
+            $elementButtonTester = new ElementButtonTester($actual);
+            call_user_func($closure, $elementButtonTester);
+            $buttons_matches = $elementButtonTester->getMatch();
+        }
+
+        return ($attributes_matches && $buttons_matches) ? true : false;
+    }
+}


### PR DESCRIPTION
Added methods to fully test questions and FB templates

There are new tests written to see almost all new methods in action.

There will be a conflict with `assertTemplate` method. Currently it expects second (optional) parameter to be boolean `$strict` but in this PR it expects a closure. Old "strict" comparison was bad call because it actually does not differ from `assertRaw`.