### PR TITLE
Make it possible to add a payload to the receives method

### DIFF
--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -110,11 +110,12 @@ class BotManTester
 
     /**
      * @param string $message
+     * @param null $payload
      * @return $this
      */
-    public function receives($message)
+    public function receives($message, $payload = null)
     {
-        return $this->receivesRaw(new IncomingMessage($message, $this->user_id, $this->channel));
+        return $this->receivesRaw(new IncomingMessage($message, $this->user_id, $this->channel, $payload));
     }
 
     /**


### PR DESCRIPTION
With this addon it is possible to send the payload with the incoming request in tests (= receives method).
So when you receive additional data through the request like `extra` here:

```
{
    "driver": "web",
    "message": "Hello",
    "userId": "1234",
    "extra": true
}
```

and you use this info for deciding how to reply to the user, then you can now do that in your BotMan tests as well:

```
$this->bot->receives('Hello', ['extra' => true]);
```

Now your application will response correctly.