### PR TITLE
Add new template-in assertions and tests

### DIFF
--- a/.discovery/Discovery.php
+++ b/.discovery/Discovery.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace TheCodingMachine\Discovery;
+
+/**
+ * Use this class to access data stored in the discovery.json files at the root of your packages.
+ */
+class Discovery implements DiscoveryInterface
+{
+    private static $instance;
+
+    /**
+     * @var string[]
+     */
+    private $values;
+    /**
+     * @var AssetType[]
+     */
+    private $assetTypes;
+    /**
+     * @var array[]
+     */
+    private $assetTypesArray;
+
+    /**
+     * Singleton. Noone creates this object directly.
+     */
+    private function __construct()
+    {
+        $this->values = require __DIR__.'/discovery_values.php';
+        $this->assetTypesArray = require __DIR__.'/discovery_asset_types.php';
+    }
+
+    /**
+     * Returns the unique instance of this class (singleton).
+     *
+     * @return self
+     */
+    public static function getInstance(): self
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Returns the asset values of the requested type.
+     *
+     * If no assets are found, an empty array is returned.
+     *
+     * @param string $assetType
+     * @return string[]
+     */
+    public function get(string $assetType) : array
+    {
+        return $this->values[$assetType] ?? [];
+    }
+
+    /**
+     * Returns an asset type object for the requested type.
+     *
+     * If no assets are found, an AssetType object containing no assets is returned.
+     *
+     * @param string $assetType
+     * @return AssetTypeInterface
+     */
+    public function getAssetType(string $assetType) : AssetTypeInterface
+    {
+        if (!isset($this->assetTypes[$assetType])) {
+            if (isset($this->assetTypesArray[$assetType])) {
+                $this->assetTypes[$assetType] = ImmutableAssetType::fromArray($assetType, $this->assetTypesArray[$assetType]);
+            } else {
+                $this->assetTypes[$assetType] = ImmutableAssetType::fromArray($assetType, []);
+            }
+        }
+        return $this->assetTypes[$assetType];
+    }
+}

--- a/.discovery/discovery_asset_types.php
+++ b/.discovery/discovery_asset_types.php
@@ -1,0 +1,3 @@
+<?php
+return array (
+);

--- a/.discovery/discovery_values.php
+++ b/.discovery/discovery_values.php
@@ -1,0 +1,3 @@
+<?php
+return array (
+);

--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -355,6 +355,30 @@ class BotManTester
     }
 
     /**
+     * @param array $templates
+     * @return $this
+     */
+    public function assertTemplateIn(array $templates)
+    {
+        $message = $this->getReply();
+        PHPUnit::assertTrue(in_array($message, $templates));
+
+        return $this;
+    }
+
+    /**
+     * @param array $templates
+     * @return $this
+     */
+    public function assertTemplateNotIn(array $templates)
+    {
+        $message = $this->getReply();
+        PHPUnit::assertFalse(in_array($message, $templates));
+
+        return $this;
+    }
+
+    /**
      * @param OutgoingMessage $message
      * @return $this
      */

--- a/tests/BotManTesterTest.php
+++ b/tests/BotManTesterTest.php
@@ -18,12 +18,10 @@ use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 
 class TemplateFake
 {
-
     public $text;
 
     public function __construct($text)
     {
-
         $this->text = $text;
     }
 }

--- a/tests/BotManTesterTest.php
+++ b/tests/BotManTesterTest.php
@@ -16,11 +16,13 @@ use BotMan\BotMan\Messages\Outgoing\Question;
 use BotMan\BotMan\Messages\Attachments\Location;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 
-class TemplateFake {
+class TemplateFake
+{
 
     public $text;
 
-    public function __construct($text) {
+    public function __construct($text)
+    {
 
         $this->text = $text;
     }

--- a/tests/BotManTesterTest.php
+++ b/tests/BotManTesterTest.php
@@ -16,6 +16,16 @@ use BotMan\BotMan\Messages\Outgoing\Question;
 use BotMan\BotMan\Messages\Attachments\Location;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 
+class TemplateFake {
+
+    public $text;
+
+    public function __construct($text) {
+
+        $this->text = $text;
+    }
+}
+
 class BotManTesterTest extends TestCase
 {
     /** @var BotManTester */
@@ -180,6 +190,62 @@ class BotManTesterTest extends TestCase
             'message 2',
             'message 3',
         ]);
+    }
+
+    /** @test */
+    public function it_can_assert_a_template_class()
+    {
+        $this->botman->hears('message', function ($bot) {
+            $bot->reply(new TemplateFake('my message'));
+        });
+
+        $this->tester->receives('message');
+        $this->tester->assertTemplate(TemplateFake::class);
+    }
+
+    /** @test */
+    public function it_can_assert_a_template_object()
+    {
+        $this->botman->hears('message', function ($bot) {
+            $bot->reply(new TemplateFake('my message'));
+        });
+
+        $this->tester->receives('message');
+        $this->tester->assertTemplate(new TemplateFake('my message'), true);
+    }
+
+    /** @test */
+    public function it_can_assert_a_template_is_in_an_array()
+    {
+        $this->botman->hears('message', function ($bot) {
+            $bot->reply(new TemplateFake('message1'));
+        });
+
+        $templates = [
+            new TemplateFake('message1'),
+            new TemplateFake('message2'),
+            new TemplateFake('message3'),
+        ];
+
+        $this->tester->receives('message');
+        $this->tester->assertTemplateIn($templates);
+    }
+
+    /** @test */
+    public function it_can_assert_a_template_is_not_in_an_array()
+    {
+        $this->botman->hears('message', function ($bot) {
+            $bot->reply(new TemplateFake('message4'));
+        });
+
+        $templates = [
+            new TemplateFake('message1'),
+            new TemplateFake('message2'),
+            new TemplateFake('message3'),
+        ];
+
+        $this->tester->receives('message');
+        $this->tester->assertTemplateNotIn($templates);
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds assertions like `assertReplyIn` and `assertReplyNotIn` for templates (objects).
--> `assertTemplateIn` and `assertTemplateNotIn`.

This is especially useful when you use templates with random text.