### PR TITLE
Change wrong namespace

### DIFF
--- a/src/Console/Commands/BotManMakeConversation.php
+++ b/src/Console/Commands/BotManMakeConversation.php
@@ -50,7 +50,7 @@ class BotManMakeConversation extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\Http\Conversations';
+        return $rootNamespace.'\Conversations';
     }
 
     /**


### PR DESCRIPTION
This PR changes the namespace of the generated conversation from `app\Http\Converstaion` to `app\Conversation`, which is used for the base example conversation as well.