### PR TITLE
Change wrong namespace

### DIFF
--- a/src/Console/Commands/BotManMakeTest.php
+++ b/src/Console/Commands/BotManMakeTest.php
@@ -34,7 +34,7 @@ class BotManMakeTest extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__.'/stubs/test.stub';
+        return __DIR__ . '/stubs/test.stub';
     }
 
     /**
@@ -45,6 +45,6 @@ class BotManMakeTest extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace.'\..\tests\Botman';
+        return $rootNamespace . '\..\tests\BotMan';
     }
 }

--- a/src/Console/Commands/BotManMakeTest.php
+++ b/src/Console/Commands/BotManMakeTest.php
@@ -34,7 +34,7 @@ class BotManMakeTest extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/stubs/test.stub';
+        return __DIR__.'/stubs/test.stub';
     }
 
     /**
@@ -45,6 +45,6 @@ class BotManMakeTest extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\..\tests\BotMan';
+        return $rootNamespace.'\..\tests\BotMan';
     }
 }


### PR DESCRIPTION
This PR changes the namespace of the generated test from tests\Botman to tests\BotMan.