### PR TITLE
Add botman:cache:clear command

### DIFF
--- a/src/Console/Commands/BotManCacheClear.php
+++ b/src/Console/Commands/BotManCacheClear.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BotMan\Studio\Console\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Console\GeneratorCommand;
+
+class BotManCacheClear extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'botman:cache:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove all cached conversations.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param \Illuminate\Filesystem\Filesystem $files
+     * @return mixed
+     */
+    public function handle(Filesystem $files)
+    {
+        $cacheFolder = storage_path('botman');
+
+        if ($files->exists($cacheFolder)) {
+            $files->cleanDirectory($cacheFolder);
+        }
+
+        $this->info('BotMan cache cleared!');
+    }
+}

--- a/src/Providers/StudioServiceProvider.php
+++ b/src/Providers/StudioServiceProvider.php
@@ -5,6 +5,7 @@ namespace BotMan\Studio\Providers;
 use Illuminate\Support\ServiceProvider;
 use TheCodingMachine\Discovery\Discovery;
 use BotMan\Studio\Console\Commands\BotManMakeTest;
+use BotMan\Studio\Console\Commands\BotManCacheClear;
 use BotMan\Studio\Console\Commands\BotManListDrivers;
 use BotMan\Studio\Console\Commands\BotManInstallDriver;
 use BotMan\Studio\Console\Commands\BotManMakeMiddleware;
@@ -23,6 +24,7 @@ class StudioServiceProvider extends ServiceProvider
             BotManMakeMiddleware::class,
             BotManMakeConversation::class,
             BotManMakeTest::class,
+            BotManCacheClear::class,
         ]);
 
         $this->discoverCommands();


### PR DESCRIPTION
This PR adds a `botman:cache:clear` command that clears the `storage/botman` cache directory.

While testing the cache folder gets filled with tons of files and you have to search for the recently generated file in order to inspect the stored data.

With this command you can simply remove all conversations and start from scratch.