### PR TITLE
Fixes StyleCI builds

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -3,4 +3,3 @@ preset: laravel
 enabled:
   - unalign_double_arrow
 
-linting: true


### PR DESCRIPTION
Remove deprecated `linting` key, so StyleCI stops failing on PR's.