### PR TITLE
Update illuminate versions constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update --preview

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         "php": ">=7.0",
         "botman/botman": "~2.0|~3.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0",
-        "illuminate/console": "~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/console": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "thecodingmachine/discovery": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
-        "orchestra/testbench": "~3.5.0",
+        "phpunit/phpunit": "~6.0|~7.5",
+        "orchestra/testbench": "~3.5.0|~3.8.0",
         "mockery/mockery": "dev-master"
     },
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
         >
     <testsuites>
         <testsuite name="Package Test Suite">


### PR DESCRIPTION
Reopen of #32 

This PR adds the ability to use the package in Laravel 5.8 components.

As part of an upgrade, I changed related packages constraints, to match those used in Laravel 5.8. This way, we can be sure, that everything works fine.

This PR may not be perfect, and I will appreciate feedback on how to make it better for community use.