### PR TITLE
[Laravel 5.8] Fix process parameters

### DIFF
--- a/src/Composer.php
+++ b/src/Composer.php
@@ -14,9 +14,9 @@ class Composer extends BaseComposer
      */
     public function install($package, callable $callback)
     {
-        $process = $this->getProcess();
+        $command = array_merge($this->findComposer(), ['require'], [$package]);
 
-        $process->setCommandLine(trim($this->findComposer().' require '.$package));
+        $process = $this->getProcess($command);
 
         $process->run($callback);
 


### PR DESCRIPTION
# This is a breaking change!

Laravel 5.8 changed the signature of `Illuminate\Support\Composer::getProcess()`. Attempting to install drives from Botman Studio now throws an error.

## Error

Too few arguments to function `Illuminate\Support\Composer::getProcess()`
`0` passed in [vendor/botman/studio-addons/src/Composer.php:17](https://github.com/botman/studio-addons/blob/1.5.0/src/Composer.php#L17)
`1` expected at [vendor/laravel/framework/src/Illuminate/Support/Composer.php:93](https://github.com/laravel/framework/blob/v5.8.0/src/Illuminate/Support/Composer.php#L93)

## Fix

Instead of passing the command as a string to `setCommandLine()`, this PR passes the command as an array to `getProcess()`.

## References
* https://github.com/laravel/framework/pull/27610
* https://github.com/laravel/framework/commit/d1b948103b9933d9881c280df39b289f324bcceb#diff-10f3aec8c5912d20246f5df216548880L78