### PR TITLE
Added channel setter for tests

### DIFF
--- a/src/Testing/BotManTester.php
+++ b/src/Testing/BotManTester.php
@@ -93,6 +93,17 @@ class BotManTester
     }
 
     /**
+     * @param string $channel
+     * @return $this
+     */
+    public function setChannel($channel)
+    {
+        $this->channel = $channel ?? $this->channel;
+
+        return $this;
+    }
+
+    /**
      * @param IncomingMessage $message
      * @return $this
      */

--- a/tests/BotManTesterTest.php
+++ b/tests/BotManTesterTest.php
@@ -99,7 +99,7 @@ class BotManTesterTest extends TestCase
     public function it_can_fake_channel()
     {
         $this->botman->hears('message', function ($bot) {
-            $bot->reply('Recipient: ' . $bot->getMessage()->getRecipient());
+            $bot->reply('Recipient: '.$bot->getMessage()->getRecipient());
         });
 
         $this->tester->setChannel(123);

--- a/tests/BotManTesterTest.php
+++ b/tests/BotManTesterTest.php
@@ -96,6 +96,21 @@ class BotManTesterTest extends TestCase
     }
 
     /** @test */
+    public function it_can_fake_channel()
+    {
+        $this->botman->hears('message', function ($bot) {
+            $bot->reply('Recipient: ' . $bot->getMessage()->getRecipient());
+        });
+
+        $this->tester->setChannel(123);
+        $this->tester->receives('message');
+        $messages = $this->tester->getMessages();
+
+        $this->assertCount(1, $messages);
+        $this->tester->assertReply('Recipient: 123');
+    }
+
+    /** @test */
     public function it_can_assert_replies()
     {
         $this->botman->hears('message', function ($bot) {


### PR DESCRIPTION
Currently, there is only one way to set recipient (channel) in tests by instantiating the `IncomingMessage` class:

```php
$incoming1 = new IncomingMessage('hi', $sender, $recipient, ['foo' => 'bar']);
$incoming2 = new IncomingMessage('good', $sender, $recipient, ['foo' => 'bar']);

$this->bot
    ->setUser($sender)
    ->receivesRaw($incoming1)
    ->assertQuestion('How are you?')
    ->receivesRaw($incoming2);
```

This PR adds an ability to make it easier through a `setChannel` setter:

```php
$this->bot
    ->setUser($sender)
    ->setChannel($channel)
    ->receives('hi', ['foo' => 'bar'])
    ->assertQuestion('How are you?')
    ->receives('good', ['foo' => 'bar']);
```

It's really useful in conversations. Otherwise, you should instantiate `IncomingMessage` for every message in a conversation.

Partially solves this issue https://github.com/botman/botman/issues/1218